### PR TITLE
Use tileCount if width/height is undefined

### DIFF
--- a/export_to_godot_tileset.js
+++ b/export_to_godot_tileset.js
@@ -110,7 +110,12 @@ class GodotTilesetExporter {
         return Math.floor(this.tileset.imageWidth / this.tileset.tileWidth);
     }
 
-    getTilesetTemplate() {
+        getTilesetTemplate() {
+        let { imageWidth, imageHeight, tileCount } = this.tileset
+        if (imageWidth === undefined || imageHeight === undefined) {
+            imageWidth = tileCount
+            imageHeight = tileCount
+        }
         // noinspection JSUnresolvedVariable
         return `[gd_resource type="TileSet" load_steps=3 format=2]
 
@@ -121,7 +126,7 @@ ${this.shapesResources}[resource]
 0/texture = ExtResource( 1 )
 0/tex_offset = Vector2( 0, 0 )
 0/modulate = Color( 1, 1, 1, 1 )
-0/region = Rect2( 0, 0, ${this.tileset.imageWidth}, ${this.tileset.imageHeight} )
+0/region = Rect2( 0, 0, ${imageWidth}, ${imageHeight} )
 0/tile_mode = 2
 0/autotile/icon_coordinate = Vector2( 0, 0 )
 0/autotile/tile_size = Vector2( ${this.tileset.tileWidth}, ${this.tileset.tileHeight} )


### PR DESCRIPTION
This fixes the undefined problem. Counter-intuitively, `tileCount` is the pixel-size of the whole sheet, at least on tiled 1.3.3.